### PR TITLE
Improve selection drawing and state sharing

### DIFF
--- a/src/components/painter/canvas/Canvas.tsx
+++ b/src/components/painter/canvas/Canvas.tsx
@@ -54,7 +54,11 @@ export default function Canvas({
   const startAnimation = () => {
     if (animIdRef.current) cancelAnimationFrame(animIdRef.current);
     const animate = () => {
-      if (selectionState.hasSelection()) {
+      if (
+        selectionState.hasSelection() ||
+        selectionState.tempRect ||
+        selectionState.tempLassoPoints.length > 0
+      ) {
         dashOffsetRef.current = (dashOffsetRef.current + 0.5) % 12;
         setAnimationTick(t => t + 1);
         animIdRef.current = requestAnimationFrame(animate);
@@ -490,6 +494,15 @@ export default function Canvas({
     }
   };
 
+  const handleDoubleClick = () => {
+    if (pointer.tool === 'selection') {
+      selectionState.reset();
+      stopAnimation();
+      onSelectionUpdate?.();
+      onSelectionEnd?.();
+    }
+  };
+
   return (
     <div className="flex flex-1 w-full h-full bg-background overflow-hidden relative">
       <div className="flex items-center justify-center w-full h-full">
@@ -505,6 +518,7 @@ export default function Canvas({
           onPointerDown={handlePointerDown}
           onPointerMove={handlePointerMove}
           onPointerUp={handlePointerUp}
+          onDoubleClick={handleDoubleClick}
         />
       </div>
     </div>

--- a/src/hooks/useSelectionState.ts
+++ b/src/hooks/useSelectionState.ts
@@ -1,4 +1,3 @@
-import { useRef } from 'react';
 import type { SelectionRect } from '../types/ui';
 
 export type SelectionMode =
@@ -43,10 +42,10 @@ export interface SelectionState {
   ) => void;
 }
 
-export default function useSelectionState(): SelectionState {
-  const stateRef = useRef<SelectionState | null>(null);
+let globalState: SelectionState | null = null;
 
-  if (!stateRef.current) {
+export default function useSelectionState(): SelectionState {
+  if (!globalState) {
     const state: SelectionState = {
       mode: 'rect',
       version: 0,
@@ -305,8 +304,8 @@ export default function useSelectionState(): SelectionState {
         state.version++;
       }
     };
-    stateRef.current = state;
+    globalState = state;
   }
 
-  return stateRef.current;
+  return globalState;
 }


### PR DESCRIPTION
## Summary
- share selection state globally so sidebar and canvas reference the same object
- always animate selection dashed lines while dragging
- allow double-click to clear the selection

## Testing
- `npm test`
- `npm run typecheck`
- `npm run lint` *(fails: 'fs' is defined but never used, 'path' is defined but never used, 'baseName' is never reassigned)*

------
https://chatgpt.com/codex/tasks/task_e_684c0e6e8750832ba8ea46cc9a03283f