### PR TITLE
Fix inpaint misalignment

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -1,8 +1,6 @@
 import esbuild from "esbuild";
 import process from "process";
 import builtins from "builtin-modules";
-import fs from "fs";
-import path from "path";
 
 const banner =
 `/*

--- a/src/service/api/ai-tool/combine-image-mask.ts
+++ b/src/service/api/ai-tool/combine-image-mask.ts
@@ -44,14 +44,17 @@ namespace Internal {
         loadImage(maskData)
       ]);
 
-      // Canvasで合成処理
+      // 画像とマスクのサイズを統一
+      const width = image.width;
+      const height = image.height;
+
       const canvas = document.createElement('canvas');
-      canvas.width = image.width;
-      canvas.height = image.height;
+      canvas.width = width;
+      canvas.height = height;
       const ctx = canvas.getContext('2d')!;
 
-      // 画像を描画
-      ctx.drawImage(image, 0, 0);
+      // 画像をリサイズして描画
+      ctx.drawImage(image, 0, 0, width, height);
 
       // 画像データを取得
       const imageDataObj = ctx.getImageData(0, 0, canvas.width, canvas.height);
@@ -59,11 +62,11 @@ namespace Internal {
 
       // マスク用のcanvasを作成
       const maskCanvas = document.createElement('canvas');
-      maskCanvas.width = mask.width;
-      maskCanvas.height = mask.height;
+      maskCanvas.width = width;
+      maskCanvas.height = height;
       const maskCtx = maskCanvas.getContext('2d')!;
-      maskCtx.drawImage(mask, 0, 0);
-      const maskDataObj = maskCtx.getImageData(0, 0, maskCanvas.width, maskCanvas.height);
+      maskCtx.drawImage(mask, 0, 0, width, height);
+      const maskDataObj = maskCtx.getImageData(0, 0, width, height);
       const maskPixels = maskDataObj.data;
 
       // インペイント用：マスクの白い部分（255）を透明に、黒い部分（0）を不透明にする

--- a/src/service/api/painter-tool/export-merged-image.ts
+++ b/src/service/api/painter-tool/export-merged-image.ts
@@ -93,7 +93,7 @@ namespace Internal {
     }
     
     const ext = 'png';
-    let baseName = `merged-${Date.now()}.${ext}`;
+    const baseName = `merged-${Date.now()}.${ext}`;
     let fullPath = normalizePath(`${folder}/${baseName}`);
     let i = 1;
     while (app.vault.getAbstractFileByPath(fullPath)) {


### PR DESCRIPTION
## Summary
- resize mask to match the image when combining
- clean up unused imports in esbuild config
- use const for base filename in export

## Testing
- `npm run lint`
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_684c0e73bcb4832bbc42081fe2dd310a